### PR TITLE
Interfaced componnets

### DIFF
--- a/dev/.cproject
+++ b/dev/.cproject
@@ -162,7 +162,9 @@
 						</toolChain>
 					</folderInfo>
 					<fileInfo id="cdt.managedbuild.config.gnu.macosx.exe.debug.529900444.282686511.480698372" name="utHierarchy.cpp" rcbsApplicability="disable" resourcePath="tests/utHierarchy.cpp" toolsToInvoke="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.exe.debug.224706638.981877601">
-						<tool id="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.exe.debug.224706638.981877601" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.exe.debug.224706638"/>
+						<tool id="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.exe.debug.224706638.981877601" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.exe.debug.224706638">
+							<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.176437907" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
+						</tool>
 					</fileInfo>
 					<fileInfo id="cdt.managedbuild.config.gnu.macosx.exe.debug.529900444.282686511.1257288857" name="utVector.cpp" rcbsApplicability="disable" resourcePath="tests/utVector.cpp" toolsToInvoke="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.exe.debug.224706638.854239850">
 						<tool id="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.exe.debug.224706638.854239850" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.macosx.exe.debug.224706638">
@@ -172,7 +174,7 @@
 					<sourceEntries>
 						<entry excluding="tests|src" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
 						<entry excluding="main.cpp" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="src"/>
-						<entry excluding="utHierarchy.cpp|utVector.cpp" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="tests"/>
+						<entry excluding="testPhysics.h|utHierarchy.cpp|utVector.cpp" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="tests"/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>

--- a/dev/src/BasicPhysics.cpp
+++ b/dev/src/BasicPhysics.cpp
@@ -1,0 +1,29 @@
+/*
+ * BasicPhysics.cpp
+ *
+ *  Created on: Mar 17, 2017
+ *      Author: sunlightiv
+ */
+
+#include "BasicPhysics.h"
+
+namespace comps {
+
+BasicPhysics::BasicPhysics() {
+	// TODO Auto-generated constructor stub
+
+}
+
+BasicPhysics::~BasicPhysics() {
+	// TODO Auto-generated destructor stub
+}
+
+const phys::Vector& BasicPhysics::getPosition() const {
+	return position;
+}
+
+void BasicPhysics::setPosition(const phys::Vector& position) {
+	this->position = position;
+}
+
+} /* namespace comps */

--- a/dev/src/BasicPhysics.h
+++ b/dev/src/BasicPhysics.h
@@ -1,0 +1,28 @@
+/*
+ * BasicPhysics.h
+ *
+ *  Created on: Mar 17, 2017
+ *      Author: sunlightiv
+ */
+
+#ifndef BASICPHYSICS_H_
+#define BASICPHYSICS_H_
+
+#include "Physics.h"
+#include "Vector.h"
+namespace comps {
+
+class BasicPhysics: public Physics {
+public:
+	BasicPhysics();
+	virtual ~BasicPhysics();
+	const phys::Vector& getPosition() const;
+	void setPosition(const phys::Vector& position);
+
+private:
+	phys::Vector position = phys::Vector(0,0,0);
+};
+
+} /* namespace comps */
+
+#endif /* BASICPHYSICS_H_ */

--- a/dev/src/Canvas.cpp
+++ b/dev/src/Canvas.cpp
@@ -1,0 +1,21 @@
+/*
+ * Canvas.cpp
+ *
+ *  Created on: Mar 17, 2017
+ *      Author: sunlightiv
+ */
+
+#include "Canvas.h"
+
+namespace cnvs {
+
+Canvas::Canvas() {
+	// TODO Auto-generated constructor stub
+
+}
+
+Canvas::~Canvas() {
+	// TODO Auto-generated destructor stub
+}
+
+} /* namespace cnvs */

--- a/dev/src/Canvas.h
+++ b/dev/src/Canvas.h
@@ -1,0 +1,21 @@
+/*
+ * Canvas.h
+ *
+ *  Created on: Mar 17, 2017
+ *      Author: sunlightiv
+ */
+
+#ifndef CANVAS_H_
+#define CANVAS_H_
+
+namespace cnvs {
+
+class Canvas {
+public:
+	Canvas();
+	virtual ~Canvas();
+};
+
+} /* namespace cnvs */
+
+#endif /* CANVAS_H_ */

--- a/dev/src/Drawable.cpp
+++ b/dev/src/Drawable.cpp
@@ -1,0 +1,21 @@
+/*
+ * Drawable.cpp
+ *
+ *  Created on: Mar 17, 2017
+ *      Author: sunlightiv
+ */
+
+#include "Drawable.h"
+
+namespace comps {
+
+Drawable::Drawable() {
+	// TODO Auto-generated constructor stub
+
+}
+
+Drawable::~Drawable() {
+	// TODO Auto-generated destructor stub
+}
+
+} /* namespace comps */

--- a/dev/src/Drawable.h
+++ b/dev/src/Drawable.h
@@ -1,0 +1,24 @@
+/*
+ * Drawable.h
+ *
+ *  Created on: Mar 17, 2017
+ *      Author: sunlightiv
+ */
+
+#ifndef DRAWABLE_H_
+#define DRAWABLE_H_
+
+#include "Component.h"
+namespace cnvs {class Canvas;}
+namespace comps {
+
+class Drawable: public Component {
+public:
+	Drawable();
+	virtual ~Drawable();
+	virtual void draw(cnvs::Canvas) = 0;
+};
+
+} /* namespace comps */
+
+#endif /* DRAWABLE_H_ */

--- a/dev/src/Invisible.cpp
+++ b/dev/src/Invisible.cpp
@@ -1,0 +1,24 @@
+/*
+ * Invisible.cpp
+ *
+ *  Created on: Mar 17, 2017
+ *      Author: sunlightiv
+ */
+
+#include "Invisible.h"
+#include "Canvas.h"
+namespace comps {
+
+Invisible::Invisible() {
+	// TODO Auto-generated constructor stub
+
+}
+
+Invisible::~Invisible() {
+	// TODO Auto-generated destructor stub
+}
+void Invisible::draw(cnvs::Canvas) {
+
+}
+
+} /* namespace comps */

--- a/dev/src/Invisible.h
+++ b/dev/src/Invisible.h
@@ -1,0 +1,23 @@
+/*
+ * Invisible.h
+ *
+ *  Created on: Mar 17, 2017
+ *      Author: sunlightiv
+ */
+
+#ifndef INVISIBLE_H_
+#define INVISIBLE_H_
+#include "Drawable.h"
+namespace cnvs {class Canvas;}
+namespace comps {
+
+class Invisible: public Drawable {
+public:
+	Invisible();
+	virtual ~Invisible();
+	virtual void draw(cnvs::Canvas);
+};
+
+} /* namespace comps */
+
+#endif /* INVISIBLE_H_ */

--- a/dev/src/Object.cpp
+++ b/dev/src/Object.cpp
@@ -7,6 +7,7 @@
 
 #include "Object.h"
 #include "Component.h"
+#include "Physics.h"
 using namespace comps;
 
 namespace objs {
@@ -20,11 +21,11 @@ Object::~Object() {
 	// TODO Auto-generated destructor stub
 }
 
-const Component* Object::getPhysics() const {
+const Physics* Object::getPhysics() const {
 	return physics;
 }
 
-void Object::setPhysics(Component* physics) {
+void Object::setPhysics(Physics* physics) {
 	physics->setParent(this);
 	this->physics = physics;
 }
@@ -36,6 +37,15 @@ const comps::Component* Object::getRender() const {
 void Object::setRender(comps::Component* render) {
 	render->setParent(this);
 	this->render = render;
+}
+
+const comps::Component* Object::getDummy() const {
+	return dummy;
+}
+
+void Object::setDummy(comps::Component* dummy) {
+	dummy->setParent(this);
+	this->dummy = dummy;
 }
 
 } /* namespace objs */

--- a/dev/src/Object.cpp
+++ b/dev/src/Object.cpp
@@ -8,6 +8,7 @@
 #include "Object.h"
 #include "Component.h"
 #include "Physics.h"
+#include "Drawable.h"
 using namespace comps;
 
 namespace objs {
@@ -30,11 +31,11 @@ void Object::setPhysics(Physics* physics) {
 	this->physics = physics;
 }
 
-const comps::Component* Object::getRender() const {
+const comps::Drawable* Object::getRender() const {
 	return render;
 }
 
-void Object::setRender(comps::Component* render) {
+void Object::setRender(comps::Drawable* render) {
 	render->setParent(this);
 	this->render = render;
 }

--- a/dev/src/Object.h
+++ b/dev/src/Object.h
@@ -7,7 +7,7 @@
 
 #ifndef OBJECT_H_
 #define OBJECT_H_
-namespace comps {class Component;}
+namespace comps {class Component; class Physics;}
 namespace worlds {class World;}
 namespace objs {
 
@@ -24,8 +24,8 @@ public:
 		this->slot = slot;
 	}
 
-	const comps::Component* getPhysics() const;
-	void setPhysics(comps::Component* physics);
+	const comps::Physics* getPhysics() const;
+	void setPhysics(comps::Physics* physics);
 	const comps::Component* getRender() const;
 	void setRender(comps::Component* render);
 
@@ -37,11 +37,15 @@ public:
 		this->parent = parent;
 	}
 
+	const comps::Component* getDummy() const;
+	void setDummy(comps::Component* dummy);
+
 private:
 	int slot;
 	worlds::World* parent;
-	comps::Component* physics;
+	comps::Physics* physics;
 	comps::Component* render;
+	comps::Component* dummy;
 };
 
 } /* namespace objs */

--- a/dev/src/Object.h
+++ b/dev/src/Object.h
@@ -7,7 +7,7 @@
 
 #ifndef OBJECT_H_
 #define OBJECT_H_
-namespace comps {class Component; class Physics;}
+namespace comps {class Component; class Physics; class Drawable;}
 namespace worlds {class World;}
 namespace objs {
 
@@ -26,8 +26,8 @@ public:
 
 	const comps::Physics* getPhysics() const;
 	void setPhysics(comps::Physics* physics);
-	const comps::Component* getRender() const;
-	void setRender(comps::Component* render);
+	const comps::Drawable* getRender() const;
+	void setRender(comps::Drawable* render);
 
 	const worlds::World* getParent() const {
 		return parent;
@@ -44,7 +44,7 @@ private:
 	int slot;
 	worlds::World* parent;
 	comps::Physics* physics;
-	comps::Component* render;
+	comps::Drawable* render;
 	comps::Component* dummy;
 };
 

--- a/dev/src/Physics.cpp
+++ b/dev/src/Physics.cpp
@@ -1,0 +1,15 @@
+/*
+ * Physics.cpp
+ *
+ *  Created on: Mar 17, 2017
+ *      Author: sunlightiv
+ */
+
+#include "Physics.h"
+
+namespace comps {
+Physics::~Physics() {
+	// TODO Auto-generated destructor stub
+}
+
+} /* namespace comps */

--- a/dev/src/Physics.h
+++ b/dev/src/Physics.h
@@ -1,0 +1,24 @@
+/*
+ * Physics.h
+ *
+ *  Created on: Mar 17, 2017
+ *      Author: sunlightiv
+ */
+
+#ifndef PHYSICS_H_
+#define PHYSICS_H_
+
+#include "Component.h"
+namespace phys {class Vector;}
+namespace comps {
+
+class Physics: public Component {
+public:
+	virtual ~Physics();
+	virtual const phys::Vector& getPosition() const = 0;
+	virtual void setPosition(const phys::Vector&) = 0;
+};
+
+} /* namespace comps */
+
+#endif /* PHYSICS_H_ */

--- a/dev/tests/utHierarchy.cpp
+++ b/dev/tests/utHierarchy.cpp
@@ -11,7 +11,6 @@
 using namespace worlds;
 using namespace objs;
 using namespace comps;
-
 TEST_CASE("Slot assignment", "[Hierarchy]") {
 	World world = World();
 	Object object0 = Object();
@@ -20,8 +19,8 @@ TEST_CASE("Slot assignment", "[Hierarchy]") {
 	Component comp2 = Component();
 	world.add(&object0);
 	world.add(&object1);
-	object0.setPhysics(&comp1);
-	object1.setPhysics(&comp2);
+	object0.setDummy(&comp1);
+	object1.setDummy(&comp2);
 	REQUIRE(object0.getSlot()==0);
 	REQUIRE(object1.getSlot()==1);
 }
@@ -33,8 +32,8 @@ TEST_CASE("Parent assignment", "[Hierarchy]") {
 	Component comp2 = Component();
 	world.add(&object0);
 	world.add(&object1);
-	object0.setPhysics(&comp1);
-	object1.setPhysics(&comp2);
+	object0.setDummy(&comp1);
+	object1.setDummy(&comp2);
 	REQUIRE(object0.getParent()==&world);
 	REQUIRE(object1.getParent()==&world);
 	REQUIRE(comp1.getParent()==&object0);


### PR DESCRIPTION
- All physics components must now implement the Physics abstract
interface
- Added a dummy component slot for unit test purposes
- All render components must now implement the Drawable abstract
interface
- Added a Canvas class (no functionality, simply needed for the type
signature of one function in Drawable)
- Added Invisible class for objects that wish to not be drawn
(implements Drawable but does nothing when drawn)